### PR TITLE
Review tic tac toe multiplayer functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,7 +85,7 @@ let ratingSelected = 0;
 // Online elements
 const onlineSetupEl = document.getElementById('onlineSetup');
 const playerNameInput = document.getElementById('playerNameInput');
-const roomCodeInput = document.getElementById('roomCodeInput');
+const roomCodeInput = document.getElementById('joinCodeInput');
 const createRoomBtn = document.getElementById('createRoomBtn');
 const joinRoomBtn = document.getElementById('joinRoomBtn');
 const roomStatusEl = document.getElementById('roomStatus');


### PR DESCRIPTION
Correct `roomCodeInput` JavaScript reference to `joinCodeInput` to restore multiplayer room joining.

A previous commit (`394d28f`) changed the HTML ID of the room code input field from `roomCodeInput` to `joinCodeInput` without updating the JavaScript, causing the 'join room' functionality to fail silently. This PR aligns the JavaScript with the current HTML ID.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f32b717-c7a6-4b6a-95df-0995f9011c5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f32b717-c7a6-4b6a-95df-0995f9011c5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

