### PR TITLE
Fix sudoku grid loading issue

### DIFF
--- a/sudoku/play.html
+++ b/sudoku/play.html
@@ -26,7 +26,7 @@
 
     <section class="sudoky__stage">
       <div class="sudoky__gridCard">
-        <div id="sudoku-grid" class="board" role="grid" aria-label="Sudoku grid"></div>
+        <div id="sudoku-grid" role="grid" aria-label="Sudoku grid"></div>
       </div>
 
       <div class="sudoky__actions" aria-label="Tools">


### PR DESCRIPTION
Remove `class="board"` from `#sudoku-grid` to fix the hidden Sudoku grid.

The `board` class had a `display: none !important;` CSS rule, which was inadvertently hiding the Sudoku grid, preventing it from loading. Removing this class allows the grid to display correctly using its `#sudoku-grid` styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-545e433d-1461-46fc-8ad2-ceeebf0260d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-545e433d-1461-46fc-8ad2-ceeebf0260d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

